### PR TITLE
関数呼び出しでセグフォになる問題の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: build
       run: make
-    - name: test
-      run: ./kaede "foo();return 1;" 
-    # - name: test-tokenize
-    #   run: make test-tokenize
-    # - name: test-parse
-    #   run: make test-parse
-    # - name: test-run
-    #   run: make test
+    - name: test-tokenize
+      run: make test-tokenize
+    - name: test-parse
+      run: make test-parse
+    - name: test-run
+      run: make test
 

--- a/main.c
+++ b/main.c
@@ -30,6 +30,8 @@ int main(int argc, char **argv) {
         locals_len++;
         locals = locals->next;
     }
+    // locals_lenを偶数に切り上げる
+    locals_len = (locals_len + 1) / 2 * 2;
 
     // アセンブリの前半部分を出力
     printf(".intel_syntax noprefix\n");

--- a/tokenize.c
+++ b/tokenize.c
@@ -122,7 +122,6 @@ Token *tokenize() {
         if (isdigit(*p)) {
             cur = new_token(TK_NUM, cur, p, 0);
             char *q = p;
-            char *tmp;
             cur->val = strtol(p, &p, 10);
             cur->len = p - q;
             continue;


### PR DESCRIPTION
https://uchan.hateblo.jp/entry/2018/02/16/232029
このサイトいわく変数の領域確保の際にrspが16の倍数になるよう調整しなければならない、そして変数確保の前には必ずrspは16の倍数になっているため、ローカル変数の数が偶数であればうまくいきそう